### PR TITLE
Make bearer auth default for swagger

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Post, Request, UseGuards } from '@nestjs/common';
-import { ApiResponse } from '@nestjs/swagger';
+import { Controller, Post, Request, UseGuards } from '@nestjs/common';
+import { ApiBody, ApiResponse } from '@nestjs/swagger';
 import { LoginAuthRequestDto, LoginAuthResponseDto } from '@osk/shared';
 import { AuthService } from './auth.service';
 import { LocalAuthGuard } from './passport/local-auth.guard';
@@ -12,14 +12,13 @@ export class AuthController {
   @SkipAuth()
   @UseGuards(LocalAuthGuard)
   @Post('login')
+  @ApiBody({
+    type: LoginAuthRequestDto,
+  })
   @ApiResponse({
     type: LoginAuthResponseDto,
   })
-  async login(
-    @Request() req: any,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    @Body() _body: LoginAuthRequestDto,
-  ): Promise<LoginAuthResponseDto> {
+  async login(@Request() req: any): Promise<LoginAuthResponseDto> {
     return this.authService.login(req.user);
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -33,7 +33,9 @@ async function bootstrap() {
       .setTitle('Twoje OSK API')
       .setVersion('1.0')
       .addBearerAuth()
+      .addSecurityRequirements('bearer', [])
       .build();
+
     const document = SwaggerModule.createDocument(app, swaggerConfig);
     SwaggerModule.setup('api/swagger', app, document);
   }

--- a/backend/src/trainees/trainees.controller.ts
+++ b/backend/src/trainees/trainees.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
-import { ApiBearerAuth, ApiResponse } from '@nestjs/swagger';
+import { ApiResponse } from '@nestjs/swagger';
 import {
   TraineeFindAllResponseDto,
   TraineeFindOneResponseDto,
@@ -13,7 +13,6 @@ export class TraineesController {
   @ApiResponse({
     type: TraineeFindAllResponseDto,
   })
-  @ApiBearerAuth()
   @Get()
   async findAll(): Promise<TraineeFindAllResponseDto> {
     const trainees = await this.traineesService.findAll();
@@ -24,7 +23,6 @@ export class TraineesController {
   @ApiResponse({
     type: TraineeFindOneResponseDto,
   })
-  @ApiBearerAuth()
   @Get(':id')
   async findOne(@Param('id') id: string): Promise<TraineeFindOneResponseDto> {
     const trainee = await this.traineesService.findOne(+id);

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, NotFoundException, Request } from '@nestjs/common';
-import { ApiBearerAuth, ApiResponse } from '@nestjs/swagger';
+import { ApiResponse } from '@nestjs/swagger';
 import { UserTestDto } from '@osk/shared';
 import { AuthRequest } from 'auth/auth.types';
 import { UsersService } from './users.service';
@@ -8,7 +8,6 @@ import { UsersService } from './users.service';
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  @ApiBearerAuth()
   @Get('me')
   @ApiResponse({
     type: UserTestDto,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
* Make bearer auth default for swagger (removes the need to specify `ApiBearerAuth` for each endpoint)

## What part of the app is affected?
* [ ] Frontend
* [x] Backend

## Screenshots or Video Recording (if appropriate):
<!-- Provide some Screenshots or Video Recordings -->
