### PR TITLE
Make production Dockerfile multi-staged

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:16-alpine AS builder-base
 
 RUN apk --no-cache add --virtual .builds-deps build-base python3
 
@@ -15,17 +15,36 @@ COPY shared/package.json ./shared/
 
 RUN yarn install --immutable
 
-COPY . .
+COPY .eslintignore .prettierrc tsconfig.json ./
+COPY eslint-plugin/ eslint-plugin/
+
+FROM builder-base AS shared
+WORKDIR /usr/src/app
+COPY shared/ ./shared/
 
 WORKDIR /usr/src/app/shared
 RUN yarn build
 
+FROM shared AS frontend
+WORKDIR /usr/src/app
+COPY frontend/ ./frontend/
+
 WORKDIR /usr/src/app/frontend
 RUN yarn build
 
+FROM shared AS backend
+WORKDIR /usr/src/app
+COPY backend/ ./backend/
+
 WORKDIR /usr/src/app/backend
-RUN yarn copy-client
 RUN yarn build
 
-CMD ["yarn", "start:prod"]
+FROM builder-base
+WORKDIR /usr/src/app
+COPY --from=shared /usr/src/app/shared ./shared/
+COPY --from=backend /usr/src/app/backend ./backend/
+COPY --from=frontend /usr/src/app/frontend ./frontend/
 
+WORKDIR /usr/src/app/backend
+RUN yarn copy-client
+CMD ["yarn", "start:prod"]


### PR DESCRIPTION
## Description
This PR changes production Dockerfile to be a multi-staged image. This will allow us to have faster build when there are changes to only one part (backend/frontend) of the app.

### Reasoning
In the current dockerfile the build step for backend is after the build step for frontend. This causes trashing any cache for the build step of backend because if docker detects any changes in files it disregards cache of any subsequent steps.

Additionally we have copied all files of all "subprojects" before all of the builds. This meant that even if we made changes only to the backend, all steps would be trashed (as the files changed)

This PR introduces implementation of multi staged build making any changes to frontend independent from backend's cache as each stage is built in separation.

I have also played around with optimising the steps that copy files from the system to docker image — those proved to improve the speed while only changing the BE but were still prone to the issue with trashing the cache of frontend

### Quick performance comparison
#### Single-Staged
Making change only to the FE: 24.7s
Making change only to the BE: 25.4s

#### Single-Staged (Optimized)
Making change only to the FE: 21.4s
Making change only to the BE: 6.6s

#### Multi-Staged
Making change only to FE: 16.0s **`(33% decrease)`**
Making change only to the BE: 7.6s **`(70% decrease!)`**

## What part of the app is affected?
* [ ] Frontend
* [ ] Backend
* [x] Infrastructure

## Screenshots or Video Recording (if appropriate):
N/A
