### PR TITLE
Add mailgun integration + password reset

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,8 @@ MAILGUN_API_KEY=test
 MAILGUN_API_DOMAIN=https://api.eu.mailgun.net
 MAILGUN_DOMAIN=mg.twoje-osk.pl
 
+SERVER_HOSTNAME=twoje-osk.loc:3000
+
 # Admin (optional)
 ADMIN_COOKIE_SECRET=adminCookieSecret
 ADMIN_DISABLE_AUTH=true

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,10 @@ DATABASE_PORT=5432
 
 JWT_SECRET=jwtSecret
 
+MAILGUN_API_KEY=test
+MAILGUN_API_DOMAIN=https://api.eu.mailgun.net
+MAILGUN_DOMAIN=mg.twoje-osk.pl
+
 # Admin (optional)
 ADMIN_COOKIE_SECRET=adminCookieSecret
 ADMIN_DISABLE_AUTH=true

--- a/backend/.eslintrc
+++ b/backend/.eslintrc
@@ -27,7 +27,19 @@
         "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize."
       }
     ],
-    "no-warning-comments": "warn"
+    "no-warning-comments": "warn",
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        "types": {
+          "ConfigService": {
+            "message": "Use `CustomConfigService` for better type safety",
+            "fixWith": "CustomConfigService"
+          }
+        },
+        "extendDefaults": false
+      }
+    ]
   },
   "overrides": [
     {

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,6 +39,7 @@
     "@nestjs/serve-static": "^2.2.2",
     "@nestjs/swagger": "^5.2.1",
     "@nestjs/typeorm": "^8.0.3",
+    "@nextnm/nestjs-mailgun": "^2.0.0",
     "@osk/eslint-plugin": "1.0.0",
     "@osk/shared": "1.0.0",
     "@types/bcrypt": "^5.0.0",

--- a/backend/src/admin.ts
+++ b/backend/src/admin.ts
@@ -1,5 +1,4 @@
 import { Logger, Module } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import AdminJS from 'adminjs';
 import '@adminjs/express';
@@ -13,17 +12,15 @@ import { resources } from 'admin/admin.imports';
 import { optionsWithAuth, withCustomResourceOptions } from 'admin/admin.utils';
 import { RESOURCE_OVERRIDES } from 'admin/admin.constants';
 import { FAVICON, LOGO } from 'admin/admin.assets';
-import { NestConfiguration, getConfiguration } from './config/configuration';
+import { CustomConfigService } from 'config/config.service';
+import { CustomConfigModule } from 'config/config.module';
 
 @Module({
   imports: [
-    ConfigModule.forRoot({
-      load: [getConfiguration],
-    }),
     TypeOrmModule.forRootAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
-      useFactory: (configService: ConfigService<NestConfiguration>) => {
+      imports: [CustomConfigModule],
+      inject: [CustomConfigService],
+      useFactory: (configService: CustomConfigService) => {
         return {
           type: 'postgres',
           host: configService.get('database.host'),
@@ -37,9 +34,9 @@ import { NestConfiguration, getConfiguration } from './config/configuration';
       },
     }),
     AdminModule.createAdminAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
-      useFactory: (configService: ConfigService<NestConfiguration, true>) => {
+      imports: [CustomConfigModule],
+      inject: [CustomConfigService],
+      useFactory: (configService: CustomConfigService) => {
         return optionsWithAuth(
           configService.get('adminDisableAuth'),
           configService.get('adminCookieSecret'),
@@ -65,8 +62,7 @@ async function bootstrap() {
   AdminJS.registerAdapter({ Database, Resource });
 
   const app = await NestFactory.create(AppModule);
-  const configService: ConfigService<NestConfiguration> =
-    app.get(ConfigService);
+  const configService: CustomConfigService = app.get(CustomConfigService);
 
   const port = configService.get('adminPort');
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,6 +20,7 @@ import { AvailabilityModule } from './availability/availability.module';
 import { LessonsModule } from './lessons/lessons.module';
 import { MailModule } from './mail/mail.module';
 import { CustomConfigModule } from './config/config.module';
+import { ResetPasswordModule } from './reset-password/reset-password.module';
 
 @Module({
   imports: [
@@ -59,6 +60,7 @@ import { CustomConfigModule } from './config/config.module';
     AvailabilityModule,
     MailModule,
     CustomConfigModule,
+    ResetPasswordModule,
   ],
   providers: [
     {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,5 +1,4 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
@@ -9,7 +8,7 @@ import { OrganizationDomainModule } from 'organization-domain/organization-domai
 import { APP_GUARD } from '@nestjs/core';
 import { RolesGuard } from 'common/guards/roles.guard';
 import { JwtAuthGuard } from 'auth/passport/jwt-auth.guard';
-import { getConfiguration, NestConfiguration } from './config/configuration';
+import { CustomConfigService } from 'config/config.service';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { OrganizationsModule } from './organizations/organizations.module';
@@ -19,16 +18,15 @@ import { DebugModule } from './debug/debug.module';
 import { VehiclesModule } from './vehicles/vehicles.module';
 import { AvailabilityModule } from './availability/availability.module';
 import { LessonsModule } from './lessons/lessons.module';
+import { MailModule } from './mail/mail.module';
+import { CustomConfigModule } from './config/config.module';
 
 @Module({
   imports: [
-    ConfigModule.forRoot({
-      load: [getConfiguration],
-    }),
     TypeOrmModule.forRootAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
-      useFactory: (configService: ConfigService<NestConfiguration>) => {
+      imports: [CustomConfigModule],
+      inject: [CustomConfigService],
+      useFactory: (configService: CustomConfigService) => {
         return {
           type: 'postgres',
           host: configService.get('database.host'),
@@ -59,6 +57,8 @@ import { LessonsModule } from './lessons/lessons.module';
     OrganizationDomainModule,
     LessonsModule,
     AvailabilityModule,
+    MailModule,
+    CustomConfigModule,
   ],
   providers: [
     {

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { NestConfiguration } from 'config/configuration';
 import { User } from 'users/entities/user.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { CustomConfigService } from 'config/config.service';
+import { CustomConfigModule } from 'config/config.module';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { LocalStrategy } from './passport/local.strategy';
@@ -14,16 +14,17 @@ import { JwtStrategy } from './passport/jwt.strategy';
   imports: [
     TypeOrmModule.forFeature([User]),
     PassportModule,
+    CustomConfigModule,
     JwtModule.registerAsync({
-      imports: [ConfigModule],
-      useFactory: async (configService: ConfigService<NestConfiguration>) => ({
+      imports: [CustomConfigModule],
+      useFactory: async (configService: CustomConfigService) => ({
         secret: configService.get('jwtSecret'),
         signOptions: { expiresIn: '1 day' },
       }),
-      inject: [ConfigService],
+      inject: [CustomConfigService],
     }),
   ],
-  providers: [AuthService, LocalStrategy, ConfigService, JwtStrategy],
+  providers: [AuthService, LocalStrategy, JwtStrategy],
   controllers: [AuthController],
   exports: [AuthService],
 })

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -24,7 +24,7 @@ export class AuthService {
       where: { email, organization, isActive: true },
     });
 
-    if (!user) {
+    if (!user || user.password === null) {
       return null;
     }
 

--- a/backend/src/auth/passport/jwt.strategy.ts
+++ b/backend/src/auth/passport/jwt.strategy.ts
@@ -1,14 +1,13 @@
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { NestConfiguration } from 'config/configuration';
 import { JwtPayload } from '@osk/shared';
 import { RequestUser } from 'auth/auth.types';
+import { CustomConfigService } from 'config/config.service';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(configService: ConfigService<NestConfiguration>) {
+  constructor(configService: CustomConfigService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,

--- a/backend/src/config/config.module.ts
+++ b/backend/src/config/config.module.ts
@@ -1,0 +1,16 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { CustomConfigService } from './config.service';
+import { getConfiguration } from './configuration';
+
+@Global()
+@Module({
+  providers: [CustomConfigService],
+  exports: [CustomConfigService],
+  imports: [
+    ConfigModule.forRoot({
+      load: [getConfiguration],
+    }),
+  ],
+})
+export class CustomConfigModule {}

--- a/backend/src/config/config.service.ts
+++ b/backend/src/config/config.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { NestConfiguration } from './configuration';
+
+@Injectable()
+export class CustomConfigService {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  constructor(private configService: ConfigService<NestConfiguration>) {}
+
+  public get<T extends keyof NestConfiguration>(key: T) {
+    return this.configService.get(key) as NestConfiguration[T];
+  }
+}

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -15,6 +15,11 @@ interface Configuration {
   adminPort: number;
   adminCookieSecret: string;
   adminDisableAuth: boolean;
+  mailgun: {
+    apiKey: string;
+    apiDomain: string;
+    domain: string;
+  };
 }
 
 export type NestConfiguration = Flatten<Configuration>;
@@ -57,5 +62,10 @@ export const getConfiguration = (): Configuration => {
       adminDisableAuth ? '' : undefined,
     ),
     adminDisableAuth,
+    mailgun: {
+      apiKey: getVariable('MAILGUN_API_KEY'),
+      apiDomain: getVariable('MAILGUN_API_DOMAIN'),
+      domain: getVariable('MAILGUN_DOMAIN'),
+    },
   };
 };

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -16,10 +16,11 @@ interface Configuration {
   adminCookieSecret: string;
   adminDisableAuth: boolean;
   mailgun: {
-    apiKey: string;
-    apiDomain: string;
+    apiKey?: string;
+    apiDomain?: string;
     domain: string;
   };
+  hostname: string;
 }
 
 export type NestConfiguration = Flatten<Configuration>;
@@ -63,9 +64,10 @@ export const getConfiguration = (): Configuration => {
     ),
     adminDisableAuth,
     mailgun: {
-      apiKey: getVariable('MAILGUN_API_KEY'),
-      apiDomain: getVariable('MAILGUN_API_DOMAIN'),
-      domain: getVariable('MAILGUN_DOMAIN'),
+      apiKey: process.env.MAILGUN_API_KEY,
+      apiDomain: process.env.MAILGUN_API_DOMAIN,
+      domain: getVariable('MAILGUN_DOMAIN', 'localhost'),
     },
+    hostname: getVariable('SERVER_HOSTNAME'),
   };
 };

--- a/backend/src/debug/debug.controller.ts
+++ b/backend/src/debug/debug.controller.ts
@@ -1,12 +1,7 @@
-// eslint-disable-next-line max-classes-per-file
 import { Controller, Get, Headers } from '@nestjs/common';
-import { ApiProperty, ApiResponse } from '@nestjs/swagger';
+import { ApiResponse } from '@nestjs/swagger';
 import { SkipAuth } from 'auth/passport/skip-auth.guard';
-
-class GetHostNameResponseDto {
-  @ApiProperty()
-  public hostname: string;
-}
+import { GetHostNameResponseDto } from './debug.dto';
 
 @Controller('debug')
 export class DebugController {

--- a/backend/src/debug/debug.dto.ts
+++ b/backend/src/debug/debug.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetHostNameResponseDto {
+  @ApiProperty()
+  public hostname: string;
+}

--- a/backend/src/debug/debug.module.ts
+++ b/backend/src/debug/debug.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { MailModule } from 'mail/mail.module';
 import { DebugController } from './debug.controller';
 
 @Module({
   controllers: [DebugController],
+  imports: [MailModule],
 })
 export class DebugModule {}

--- a/backend/src/mail/mail.module.ts
+++ b/backend/src/mail/mail.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { MailgunModule } from '@nextnm/nestjs-mailgun';
+import { CustomConfigService } from 'config/config.service';
+import { MailService } from './mail.service';
+
+@Module({
+  imports: [
+    MailgunModule.forAsyncRoot({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: CustomConfigService) => ({
+        username: 'noreply',
+        key: configService.get('mailgun.apiKey')!,
+        url: configService.get('mailgun.apiDomain')!,
+      }),
+    }),
+  ],
+  providers: [MailService],
+  exports: [MailService],
+})
+export class MailModule {}

--- a/backend/src/mail/mail.module.ts
+++ b/backend/src/mail/mail.module.ts
@@ -11,8 +11,8 @@ import { MailService } from './mail.service';
       inject: [ConfigService],
       useFactory: (configService: CustomConfigService) => ({
         username: 'noreply',
-        key: configService.get('mailgun.apiKey')!,
-        url: configService.get('mailgun.apiDomain')!,
+        key: configService.get('mailgun.apiKey') ?? 'dummy-key',
+        url: configService.get('mailgun.apiDomain'),
       }),
     }),
   ],

--- a/backend/src/mail/mail.service.ts
+++ b/backend/src/mail/mail.service.ts
@@ -25,12 +25,16 @@ export class MailService {
       html: contents.html,
     };
 
-    if (this.configService.get('mailgun.apiKey') === undefined) {
+    if (
+      this.configService.get('mailgun.apiKey') === undefined ||
+      to.endsWith('@example.com')
+    ) {
       Logger.debug('No Mailgun API Key. Logging email contents', options);
 
       return undefined;
     }
 
-    return this.mailgunService.createEmail(domain, options);
+    await this.mailgunService.createEmail(domain, options);
+    return undefined;
   }
 }

--- a/backend/src/mail/mail.service.ts
+++ b/backend/src/mail/mail.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { EmailOptions, MailgunService } from '@nextnm/nestjs-mailgun';
 import { CustomConfigService } from 'config/config.service';
 import { EmailContents } from './mail.types';
@@ -10,7 +10,11 @@ export class MailService {
     private configService: CustomConfigService,
   ) {}
 
-  public sendEmail(to: string, subject: string, contents: EmailContents) {
+  public async sendEmail(
+    to: string,
+    subject: string,
+    contents: EmailContents,
+  ): Promise<void> {
     const domain = this.configService.get('mailgun.domain');
 
     const options: EmailOptions = {
@@ -20,6 +24,12 @@ export class MailService {
       text: contents.text,
       html: contents.html,
     };
+
+    if (this.configService.get('mailgun.apiKey') === undefined) {
+      Logger.debug('No Mailgun API Key. Logging email contents', options);
+
+      return undefined;
+    }
 
     return this.mailgunService.createEmail(domain, options);
   }

--- a/backend/src/mail/mail.service.ts
+++ b/backend/src/mail/mail.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { EmailOptions, MailgunService } from '@nextnm/nestjs-mailgun';
+import { CustomConfigService } from 'config/config.service';
+import { EmailContents } from './mail.types';
+
+@Injectable()
+export class MailService {
+  constructor(
+    private mailgunService: MailgunService,
+    private configService: CustomConfigService,
+  ) {}
+
+  public sendEmail(to: string, subject: string, contents: EmailContents) {
+    const domain = this.configService.get('mailgun.domain');
+
+    const options: EmailOptions = {
+      from: `noreply@${domain}`,
+      to,
+      subject,
+      text: contents.text,
+      html: contents.html,
+    };
+
+    return this.mailgunService.createEmail(domain, options);
+  }
+}

--- a/backend/src/mail/mail.types.ts
+++ b/backend/src/mail/mail.types.ts
@@ -1,0 +1,11 @@
+export interface TextEmailContents {
+  text: string;
+  html?: string;
+}
+
+export interface HtmlEmailContents {
+  text?: string;
+  html: string;
+}
+
+export type EmailContents = TextEmailContents | HtmlEmailContents;

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,23 +3,21 @@ import {
   Logger,
   ValidationPipe,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { NestFactory, Reflector } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { CustomConfigService } from 'config/config.service';
 import {
   initializeTransactionalContext,
   patchTypeORMRepositoryWithBaseRepository,
 } from 'typeorm-transactional-cls-hooked';
 import { AppModule } from './app.module';
-import { NestConfiguration } from './config/configuration';
 
 async function bootstrap() {
   initializeTransactionalContext();
   patchTypeORMRepositoryWithBaseRepository();
 
   const app = await NestFactory.create(AppModule);
-  const configService: ConfigService<NestConfiguration> =
-    app.get(ConfigService);
+  const configService: CustomConfigService = app.get(CustomConfigService);
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/backend/src/migrations/1664719850851-MakePasswordOptional.ts
+++ b/backend/src/migrations/1664719850851-MakePasswordOptional.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MakePasswordOptional1664719850851 implements MigrationInterface {
+    name = 'MakePasswordOptional1664719850851'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" ALTER COLUMN "password" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "user" ALTER COLUMN "isActive" SET DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" ALTER COLUMN "isActive" SET DEFAULT true`);
+        await queryRunner.query(`UPDATE "user" SET password='' WHERE "password" IS NULL;`);
+        await queryRunner.query(`ALTER TABLE "user" ALTER COLUMN "password" SET NOT NULL`);
+    }
+
+}

--- a/backend/src/migrations/1664726704486-CreateResetPasswordToken.ts
+++ b/backend/src/migrations/1664726704486-CreateResetPasswordToken.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateResetPasswordToken1664726704486 implements MigrationInterface {
+    name = 'CreateResetPasswordToken1664726704486'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "reset_password_token" ("id" SERIAL NOT NULL, "token" character varying NOT NULL, "isValid" boolean NOT NULL, "expireDate" TIMESTAMP NOT NULL, "userId" integer NOT NULL, CONSTRAINT "PK_c6f6eb8f5c88ac0233eceb8d385" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_609174ec22ebfd1b8dd71f867a" ON "reset_password_token" ("token") `);
+        await queryRunner.query(`ALTER TABLE "reset_password_token" ADD CONSTRAINT "FK_3fde3055d9d16236c05d030915e" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "reset_password_token" DROP CONSTRAINT "FK_3fde3055d9d16236c05d030915e"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_609174ec22ebfd1b8dd71f867a"`);
+        await queryRunner.query(`DROP TABLE "reset_password_token"`);
+    }
+
+}

--- a/backend/src/reset-password/entities/reset-password-token.entity.ts
+++ b/backend/src/reset-password/entities/reset-password-token.entity.ts
@@ -1,0 +1,37 @@
+import { Exclude } from 'class-transformer';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  RelationId,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity()
+export class ResetPasswordToken {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Index()
+  @Column()
+  token: string;
+
+  @Column()
+  isValid: boolean;
+
+  @Column()
+  expireDate: Date;
+
+  @ManyToOne(() => User, { nullable: false })
+  @JoinColumn()
+  user: User;
+
+  @Exclude()
+  @RelationId(
+    (resetPasswordToken: ResetPasswordToken) => resetPasswordToken.user,
+  )
+  userId: number;
+}

--- a/backend/src/reset-password/reset-password.controller.ts
+++ b/backend/src/reset-password/reset-password.controller.ts
@@ -1,9 +1,9 @@
 import {
   Body,
   Controller,
-  NotFoundException,
   Post,
   Request,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { ApiBody, ApiResponse } from '@nestjs/swagger';
 import { Request as ExpressRequest } from 'express';
@@ -56,7 +56,7 @@ export class ResetPasswordController {
     );
 
     if (!result.ok && result.error === 'TOKEN_NOT_FOUND') {
-      throw new NotFoundException();
+      throw new UnauthorizedException();
     }
 
     return {};

--- a/backend/src/reset-password/reset-password.controller.ts
+++ b/backend/src/reset-password/reset-password.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Body,
+  Controller,
+  NotFoundException,
+  Post,
+  Request,
+} from '@nestjs/common';
+import { ApiBody, ApiResponse } from '@nestjs/swagger';
+import { Request as ExpressRequest } from 'express';
+import {
+  ForgotPasswordRequestDto,
+  ForgotPasswordResponseDto,
+  ResetPasswordRequestDto,
+  ResetPasswordResponseDto,
+} from '@osk/shared';
+import { SkipAuth } from 'auth/passport/skip-auth.guard';
+import { ResetPasswordService } from './reset-password.service';
+
+@Controller('reset-password')
+export class ResetPasswordController {
+  constructor(private resetPasswordService: ResetPasswordService) {}
+
+  @SkipAuth()
+  @Post('forgot')
+  @ApiBody({
+    type: ForgotPasswordRequestDto,
+  })
+  @ApiResponse({
+    type: ForgotPasswordResponseDto,
+  })
+  async forgotPassword(
+    @Body() { email }: ForgotPasswordRequestDto,
+    @Request() req: ExpressRequest,
+  ): Promise<ForgotPasswordResponseDto> {
+    const isHttps = req.protocol === 'https';
+    // Important! No await to mitigate timing attack
+    this.resetPasswordService.initiatePasswordReset(email, isHttps);
+
+    return {};
+  }
+
+  @SkipAuth()
+  @Post('reset')
+  @ApiBody({
+    type: ResetPasswordRequestDto,
+  })
+  @ApiResponse({
+    type: ResetPasswordResponseDto,
+  })
+  async resetPassword(
+    @Body() { token, password }: ResetPasswordRequestDto,
+  ): Promise<ResetPasswordResponseDto> {
+    const result = await this.resetPasswordService.resetPassword(
+      token,
+      password,
+    );
+
+    if (!result.ok && result.error === 'TOKEN_NOT_FOUND') {
+      throw new NotFoundException();
+    }
+
+    return {};
+  }
+}

--- a/backend/src/reset-password/reset-password.module.ts
+++ b/backend/src/reset-password/reset-password.module.ts
@@ -13,6 +13,7 @@ import { ResetPasswordController } from './reset-password.controller';
     TypeOrmModule.forFeature([ResetPasswordToken]),
     UsersModule,
     MailModule,
+    ResetPasswordModule,
   ],
   controllers: [ResetPasswordController],
 })

--- a/backend/src/reset-password/reset-password.module.ts
+++ b/backend/src/reset-password/reset-password.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsersModule } from 'users/users.module';
+import { MailModule } from 'mail/mail.module';
+import { ResetPasswordService } from './reset-password.service';
+import { ResetPasswordToken } from './entities/reset-password-token.entity';
+import { ResetPasswordController } from './reset-password.controller';
+
+@Module({
+  providers: [ResetPasswordService],
+  exports: [ResetPasswordService],
+  imports: [
+    TypeOrmModule.forFeature([ResetPasswordToken]),
+    UsersModule,
+    MailModule,
+  ],
+  controllers: [ResetPasswordController],
+})
+export class ResetPasswordModule {}

--- a/backend/src/reset-password/reset-password.service.ts
+++ b/backend/src/reset-password/reset-password.service.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MoreThanOrEqual, Repository } from 'typeorm';
+import { UsersService } from 'users/users.service';
+import { Try, getFailure, getSuccess } from 'types/Try';
+import { add } from 'date-fns';
+import { OrganizationDomainService } from 'organization-domain/organization-domain.service';
+import { Transactional } from 'typeorm-transactional-cls-hooked';
+import { CustomConfigService } from 'config/config.service';
+import { MailService } from 'mail/mail.service';
+import { ResetPasswordToken } from './entities/reset-password-token.entity';
+import { getToken, hashToken } from './reset-password.utils';
+
+@Injectable()
+export class ResetPasswordService {
+  constructor(
+    @InjectRepository(ResetPasswordToken)
+    private resetPasswordTokenRepository: Repository<ResetPasswordToken>,
+    private usersService: UsersService,
+    private organizationDomainService: OrganizationDomainService,
+    private mailService: MailService,
+    private configService: CustomConfigService,
+  ) {}
+
+  public async create(email: string): Promise<Try<string, 'USER_NOT_FOUND'>> {
+    const user = await this.usersService.findOneByEmail(email);
+
+    if (user === null) {
+      return getFailure('USER_NOT_FOUND');
+    }
+
+    const expireDate = add(new Date(), { hours: 1 });
+
+    const { hashedToken, token } = await getToken();
+    const resetPasswordToken: Omit<ResetPasswordToken, 'id' | 'userId'> = {
+      isValid: true,
+      expireDate,
+      user,
+      token: hashedToken,
+    };
+
+    await this.resetPasswordTokenRepository.insert(resetPasswordToken);
+
+    return getSuccess(token);
+  }
+
+  public async getUserByToken(
+    token: string,
+  ): Promise<Try<ResetPasswordToken, 'TOKEN_NOT_FOUND'>> {
+    const hashedToken = hashToken(token);
+    const resetToken = await this.resetPasswordTokenRepository.findOne({
+      where: {
+        token: hashedToken,
+        expireDate: MoreThanOrEqual(new Date()),
+        isValid: true,
+      },
+      relations: {
+        user: true,
+      },
+    });
+
+    if (resetToken === null) {
+      return getFailure('TOKEN_NOT_FOUND');
+    }
+
+    const { id: organizationId } =
+      this.organizationDomainService.getRequestOrganization();
+    if (resetToken.user.organizationId !== organizationId) {
+      return getFailure('TOKEN_NOT_FOUND');
+    }
+
+    return getSuccess(resetToken);
+  }
+
+  public async invalidateToken(tokenId: number) {
+    await this.resetPasswordTokenRepository.update(
+      {
+        id: tokenId,
+      },
+      {
+        isValid: false,
+      },
+    );
+  }
+
+  async initiatePasswordReset(
+    email: string,
+    isHttps: boolean,
+  ): Promise<Try<undefined, 'UNABLE_TO_CREATE_TOKEN'>> {
+    const result = await this.create(email);
+
+    if (!result.ok) {
+      return getFailure('UNABLE_TO_CREATE_TOKEN');
+    }
+
+    const token = result.data;
+    const hostname = this.configService.get('hostname');
+    const protocol = isHttps ? 'https' : 'http';
+    const { slug } = this.organizationDomainService.getRequestOrganization();
+    const resetPasswordUrl = `${protocol}://${slug}.${hostname}/account/reset-password/${token}`;
+
+    await this.mailService.sendEmail(email, 'Password reset', {
+      html: `<a href="${resetPasswordUrl}">Reset password</a>`,
+      text: `${resetPasswordUrl}`,
+    });
+
+    return getSuccess(undefined);
+  }
+
+  @Transactional()
+  async resetPassword(
+    token: string,
+    newPassword: string,
+  ): Promise<Try<undefined, 'TOKEN_NOT_FOUND'>> {
+    const userResult = await this.getUserByToken(token);
+
+    if (!userResult.ok) {
+      return getFailure('TOKEN_NOT_FOUND');
+    }
+
+    const { user, id: tokenId } = userResult.data;
+    const { id: userId } = user;
+
+    await this.usersService.changePassword(userId, newPassword);
+    await this.invalidateToken(tokenId);
+
+    return getSuccess(undefined);
+  }
+}

--- a/backend/src/reset-password/reset-password.service.ts
+++ b/backend/src/reset-password/reset-password.service.ts
@@ -97,7 +97,7 @@ export class ResetPasswordService {
     const hostname = this.configService.get('hostname');
     const protocol = isHttps ? 'https' : 'http';
     const { slug } = this.organizationDomainService.getRequestOrganization();
-    const resetPasswordUrl = `${protocol}://${slug}.${hostname}/account/reset-password/${token}`;
+    const resetPasswordUrl = `${protocol}://${slug}.${hostname}/account/reset/${token}`;
 
     await this.mailService.sendEmail(email, 'Password reset', {
       html: `<a href="${resetPasswordUrl}">Reset password</a>`,

--- a/backend/src/reset-password/reset-password.utils.ts
+++ b/backend/src/reset-password/reset-password.utils.ts
@@ -1,0 +1,24 @@
+import { randomBytes, createHmac } from 'node:crypto';
+
+const getBytes = (size: number) =>
+  new Promise<Buffer>((resolve, reject) => {
+    randomBytes(size, (err, buffer) => {
+      if (err) {
+        return reject(err);
+      }
+
+      return resolve(buffer);
+    });
+  });
+
+export const hashToken = (token: string) =>
+  createHmac('sha256', token).digest('hex');
+
+export const getToken = async () => {
+  const bytes = await getBytes(16);
+
+  const token = bytes.toString('hex');
+  const hashedToken = hashToken(token);
+
+  return { hashedToken, token };
+};

--- a/backend/src/seeds/seed.ts
+++ b/backend/src/seeds/seed.ts
@@ -14,7 +14,7 @@ const clearSequences = async (trx: EntityManager) => {
     SELECT SETVAL(c.oid, s.start_value, false) FROM pg_class c
       JOIN pg_namespace pn on c.relnamespace = pn.oid
       JOIN pg_sequences s on s.sequencename = c.relname
-    WHERE c.relkind = 'S';
+    WHERE c.relkind = 'S' AND c.relname != 'migrations_id_seq';
   `);
 };
 

--- a/backend/src/trainees/trainees.controller.ts
+++ b/backend/src/trainees/trainees.controller.ts
@@ -8,9 +8,11 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Request,
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { ApiBody, ApiResponse } from '@nestjs/swagger';
+import { Request as ExpressRequest } from 'express';
 import {
   TraineeFindAllResponseDto,
   TraineeFindOneResponseDto,
@@ -61,8 +63,13 @@ export class TraineesController {
   @Post()
   async create(
     @Body() { trainee }: TraineeAddNewRequestDto,
+    @Request() req: ExpressRequest,
   ): Promise<TraineeAddNewResponseDto> {
-    const createTraineeCall = await this.traineesService.create(trainee);
+    const isHttps = req.protocol === 'https';
+    const createTraineeCall = await this.traineesService.create(
+      trainee,
+      isHttps,
+    );
 
     if (createTraineeCall.ok) {
       return { trainee: createTraineeCall.data };

--- a/backend/src/trainees/trainees.module.ts
+++ b/backend/src/trainees/trainees.module.ts
@@ -2,13 +2,18 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from 'users/users.module';
 import { User } from 'users/entities/user.entity';
+import { ResetPasswordModule } from 'reset-password/reset-password.module';
 import { TraineesService } from './trainees.service';
 import { TraineesController } from './trainees.controller';
 import { Trainee } from './entities/trainee.entity';
 
 @Module({
   controllers: [TraineesController],
-  imports: [TypeOrmModule.forFeature([Trainee, User]), UsersModule],
+  imports: [
+    TypeOrmModule.forFeature([Trainee, User]),
+    UsersModule,
+    ResetPasswordModule,
+  ],
   providers: [TraineesService],
   exports: [TraineesService],
 })

--- a/backend/src/types/UserArguments.ts
+++ b/backend/src/types/UserArguments.ts
@@ -1,6 +1,5 @@
 export interface UserArguments {
   email: string;
-  password: string;
   firstName: string;
   lastName: string;
   isActive: boolean;

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -22,9 +22,9 @@ export class User {
   @Column()
   email: string;
 
-  @Column()
   @Exclude()
-  password: string;
+  @Column({ nullable: true, type: 'varchar' })
+  password: string | null;
 
   @Column()
   firstName: string;
@@ -32,7 +32,7 @@ export class User {
   @Column()
   lastName: string;
 
-  @Column({ default: true })
+  @Column({ default: false })
   isActive: boolean;
 
   @ManyToOne(() => Organization, { nullable: false })

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -46,7 +46,9 @@ export class UsersController {
   async create(
     @Body() { user }: UserAddNewRequestDto,
   ): Promise<UserAddNewResponseDto> {
-    const doesUserExist = await this.usersService.findOneByEmail(user.email);
+    const doesUserExist = await this.usersService.findOneByEmailFromAll(
+      user.email,
+    );
 
     if (doesUserExist) {
       throw new ConflictException('An user with this email already exist.');

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -55,7 +55,6 @@ export class UsersController {
     return {
       user: await this.usersService.create(
         user.email,
-        user.password,
         user.firstName,
         user.lastName,
         user.isActive,

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,4 +1,3 @@
-import * as bcrypt from 'bcrypt';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { OrganizationDomainService } from 'organization-domain/organization-domain.service';
@@ -7,7 +6,6 @@ import { User } from './entities/user.entity';
 
 export interface UserArguments {
   email?: string;
-  password?: string;
   firstName?: string;
   lastName?: string;
   isActive?: boolean;
@@ -54,23 +52,19 @@ export class UsersService {
 
   async create(
     email: string,
-    password: string,
     firstName: string,
     lastName: string,
     isActive: boolean,
     phoneNumber: string,
   ) {
-    const { id: organizationId } =
-      this.organizationDomainService.getRequestOrganization();
-    const newUser = this.usersRepository.create({
+    const newUser = this.createUserWithoutSave({
       email,
-      password,
       firstName,
-      lastName,
       isActive,
-      organization: { id: organizationId },
+      lastName,
       phoneNumber,
     });
+
     await this.usersRepository.save(newUser);
 
     return newUser;
@@ -111,7 +105,7 @@ export class UsersService {
 
     const userToCreate = {
       ...user,
-      password: user.password ? bcrypt.hashSync(user.password, 10) : undefined,
+      password: undefined,
       createdAt: new Date(),
       organization: { id: organizationId },
     };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,14 @@
 import { UserRole } from '@osk/shared/src/types/user.types';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import { RequireAuth } from './components/RequireAuth/RequireAuth';
 import { RequireRole } from './components/RequireRole/RequireRole';
+import { ForgotPassword } from './views/ForgotPassword/ForgotPassword';
 import { HomePage } from './views/HomePage/HomePage';
 import { InstructorsList } from './views/Instructors/InstructorsList/InstructorsList';
 import { Layout } from './views/Layout/Layout';
 import { MyLessons } from './views/Lessons/MyLessons/MyLessons';
 import { Login } from './views/Login/Login';
+import { ResetPassword } from './views/ResetPassword/ResetPassword';
 import { TraineeDetails } from './views/Trainees/TraineeDetails/TraineeDetails';
 import { TraineeEdit } from './views/Trainees/TraineeEdit/TraineeEdit';
 import { TraineeNew } from './views/Trainees/TraineeNew/TraineeNew';
@@ -20,6 +22,11 @@ export const App = () => {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
+      <Route path="/account/zapomnialem-haslo" element={<ForgotPassword />} />
+      <Route path="/account/reset">
+        <Route index element={<Navigate to="/account/zapomnialem-haslo" />} />
+        <Route path=":token" element={<ResetPassword />} />
+      </Route>
       <Route
         path="/"
         element={

--- a/frontend/src/hooks/useUnauthorizedOrganizationData/useUnauthorizedOrganizationData.ts
+++ b/frontend/src/hooks/useUnauthorizedOrganizationData/useUnauthorizedOrganizationData.ts
@@ -1,0 +1,13 @@
+import { OrganizationGetPublicInfoResponseDto } from '@osk/shared';
+import useSWR from 'swr';
+
+export const useUnauthorizedOrganizationData = () => {
+  const { data, error } =
+    useSWR<OrganizationGetPublicInfoResponseDto>('/api/organization');
+  const oskName = data?.organization.name;
+
+  return {
+    oskName,
+    error,
+  };
+};

--- a/frontend/src/views/ForgotPassword/ForgotPassword.schema.ts
+++ b/frontend/src/views/ForgotPassword/ForgotPassword.schema.ts
@@ -1,0 +1,12 @@
+import * as Yup from 'yup';
+import { setupYupLocale } from '../../utils/setupYupLocale';
+
+export interface ForgotPasswordForm {
+  email: string;
+}
+
+setupYupLocale();
+export const ForgotPasswordFormSchema: Yup.SchemaOf<ForgotPasswordForm> =
+  Yup.object().shape({
+    email: Yup.string().required(),
+  });

--- a/frontend/src/views/ForgotPassword/ForgotPassword.styled.ts
+++ b/frontend/src/views/ForgotPassword/ForgotPassword.styled.ts
@@ -1,0 +1,19 @@
+import styled from '@emotion/styled';
+
+export const ForgotPasswordHiddenWrapper = styled.div`
+  opacity: 1;
+  transition: opacity 0.2s ease-in-out;
+
+  &.hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+`;
+
+export const ForgotPasswordLoaderWrapper = styled(ForgotPasswordHiddenWrapper)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+`;

--- a/frontend/src/views/ForgotPassword/ForgotPassword.utils.ts
+++ b/frontend/src/views/ForgotPassword/ForgotPassword.utils.ts
@@ -1,0 +1,34 @@
+import {
+  ForgotPasswordRequestDto,
+  ForgotPasswordResponseDto,
+} from '@osk/shared';
+import { Try } from '../../types/Try';
+import { logError } from '../../utils/log';
+import { makeRequest } from '../../utils/makeRequest';
+
+export const sendResetRequest = async (
+  email: string,
+): Promise<Try<ForgotPasswordResponseDto, string>> => {
+  const requestBody: ForgotPasswordRequestDto = {
+    email,
+  };
+
+  const response = await makeRequest<
+    ForgotPasswordResponseDto,
+    ForgotPasswordRequestDto
+  >('/api/reset-password/forgot', null, 'POST', requestBody);
+
+  if (response.ok) {
+    return {
+      ok: true,
+      data: response.data,
+    };
+  }
+
+  logError(response.error);
+
+  return {
+    ok: false,
+    error: 'Wystąpił błąd, spróbuj ponownie później',
+  };
+};

--- a/frontend/src/views/ResetPassword/ResetPassword.schema.ts
+++ b/frontend/src/views/ResetPassword/ResetPassword.schema.ts
@@ -1,0 +1,15 @@
+import * as Yup from 'yup';
+import { setupYupLocale } from '../../utils/setupYupLocale';
+
+export interface ResetPasswordForm {
+  password: string;
+}
+
+setupYupLocale();
+export const ResetPasswordFormSchema: Yup.SchemaOf<ResetPasswordForm> =
+  Yup.object().shape({
+    password: Yup.string()
+      .min(8, 'Hasło musi mieć minimum 8 znaków')
+      .max(64, 'Hasło może mieć maksimum 64 znaki')
+      .required(),
+  });

--- a/frontend/src/views/ResetPassword/ResetPassword.styled.ts
+++ b/frontend/src/views/ResetPassword/ResetPassword.styled.ts
@@ -1,0 +1,19 @@
+import styled from '@emotion/styled';
+
+export const ResetPasswordHiddenWrapper = styled.div`
+  opacity: 1;
+  transition: opacity 0.2s ease-in-out;
+
+  &.hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+`;
+
+export const ResetPasswordLoaderWrapper = styled(ResetPasswordHiddenWrapper)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+`;

--- a/frontend/src/views/ResetPassword/ResetPassword.tsx
+++ b/frontend/src/views/ResetPassword/ResetPassword.tsx
@@ -1,0 +1,205 @@
+import { LoadingButton } from '@mui/lab';
+import {
+  Alert,
+  AlertTitle,
+  Button,
+  Container,
+  Icon,
+  Link,
+  Paper,
+  Typography,
+} from '@mui/material';
+import { Form, Formik } from 'formik';
+import { useState } from 'react';
+import { Link as RouterLink, useParams } from 'react-router-dom';
+import { Box, Flex } from 'reflexbox';
+import { FTextField } from '../../components/FTextField/FTextField';
+import { FullPageLoading } from '../../components/FullPageLoading/FullPageLoading';
+import { GeneralAPIError } from '../../components/GeneralAPIError/GeneralAPIError';
+import { useUnauthorizedOrganizationData } from '../../hooks/useUnauthorizedOrganizationData/useUnauthorizedOrganizationData';
+import {
+  ResetPasswordForm,
+  ResetPasswordFormSchema,
+} from './ResetPassword.schema';
+import {
+  ResetPasswordHiddenWrapper,
+  ResetPasswordLoaderWrapper,
+} from './ResetPassword.styled';
+import { sendChangePasswordRequest } from './ResetPassword.utils';
+
+export const ResetPassword = () => {
+  const { oskName, error } = useUnauthorizedOrganizationData();
+  const [formError, setFormError] = useState<string | undefined>(undefined);
+  const [submissionState, setSubmissionState] = useState<
+    'not-sent' | 'success' | 'error'
+  >('not-sent');
+  const { token } = useParams();
+
+  const onSubmit = async (values: ResetPasswordForm) => {
+    if (!token) {
+      setFormError('Wystąpił błąd, spróbuj ponownie później');
+      return undefined;
+    }
+
+    setFormError(undefined);
+    const result = await sendChangePasswordRequest(values.password, token);
+
+    if (result.ok) {
+      setSubmissionState('success');
+      return undefined;
+    }
+
+    if (result.error.type === 'TOKEN_NOT_FOUND') {
+      setSubmissionState('error');
+    }
+
+    return setFormError(result.error.message);
+  };
+
+  if (error) {
+    return (
+      <Container component="main" maxWidth="sm">
+        <Flex width="100%" height="100vh" alignItems="center">
+          <Paper sx={{ width: '100%', position: 'relative' }} elevation={2}>
+            <GeneralAPIError />
+          </Paper>
+        </Flex>
+      </Container>
+    );
+  }
+
+  const isLoading = oskName === undefined;
+
+  const header = (
+    <Flex justifyContent="center" alignItems="center">
+      <Flex mr="1rem">
+        <Icon sx={{ fontSize: 48 }}>car_rental</Icon>
+      </Flex>
+      <Typography variant="h3" component="h1">
+        {oskName}
+      </Typography>
+    </Flex>
+  );
+
+  if (submissionState === 'success') {
+    return (
+      <Container component="main" maxWidth="sm">
+        <Flex width="100%" height="100vh" alignItems="center">
+          <Paper sx={{ width: '100%', position: 'relative' }} elevation={2}>
+            <Box p="2rem">
+              {header}
+              <Box marginY="1rem">
+                <Alert severity="success">Pomyślnie zmieniono hasło</Alert>
+              </Box>
+              <Button variant="outlined" component={RouterLink} to="/">
+                Wróć do logowania
+              </Button>
+            </Box>
+          </Paper>
+        </Flex>
+      </Container>
+    );
+  }
+
+  if (submissionState === 'error') {
+    return (
+      <Container component="main" maxWidth="sm">
+        <Flex width="100%" height="100vh" alignItems="center">
+          <Paper sx={{ width: '100%', position: 'relative' }} elevation={2}>
+            <Box p="2rem">
+              {header}
+              <Box marginY="1rem">
+                <Alert severity="error">
+                  <AlertTitle>
+                    Linku do resetu hasła jest nieprawidłowy
+                  </AlertTitle>
+                  Jeśli uważasz że jest to błąd, wyślij e-maila na{' '}
+                  <Link
+                    href="mailto:support@twoje-osk.pl"
+                    style={{ whiteSpace: 'nowrap' }}
+                  >
+                    support@twoje-osk.pl
+                  </Link>
+                </Alert>
+              </Box>
+              <Button variant="outlined" component={RouterLink} to="/">
+                Wróć do logowania
+              </Button>
+            </Box>
+          </Paper>
+        </Flex>
+      </Container>
+    );
+  }
+
+  return (
+    <Container component="main" maxWidth="sm">
+      <Flex width="100%" height="100vh" alignItems="center">
+        <Paper sx={{ width: '100%', position: 'relative' }} elevation={2}>
+          <ResetPasswordLoaderWrapper
+            aria-hidden={!isLoading}
+            className={!isLoading ? 'hidden' : undefined}
+          >
+            <FullPageLoading />
+          </ResetPasswordLoaderWrapper>
+          <ResetPasswordHiddenWrapper
+            aria-hidden={isLoading}
+            className={isLoading ? 'hidden' : undefined}
+          >
+            <Box p="2rem">
+              {header}
+              <Typography variant="h6" marginTop="1rem">
+                Ustaw nowe hasło
+              </Typography>
+              <Formik<ResetPasswordForm>
+                initialValues={{
+                  password: '',
+                }}
+                validationSchema={ResetPasswordFormSchema}
+                onSubmit={onSubmit}
+              >
+                {({ isSubmitting }) => (
+                  <Form noValidate>
+                    <Flex flexDirection="column">
+                      <FTextField
+                        name="password"
+                        label="Nowe hasło"
+                        type="password"
+                        margin="normal"
+                        required
+                        disabled={isLoading}
+                      />
+                      {formError && (
+                        <Box my="0.5rem">
+                          <Alert severity="error">{formError}</Alert>
+                        </Box>
+                      )}
+                      <Flex justifyContent="space-between" mt="0.5rem">
+                        <LoadingButton
+                          variant="contained"
+                          type="submit"
+                          loading={isSubmitting}
+                          disabled={isLoading}
+                        >
+                          Zmień Hasło
+                        </LoadingButton>
+                        <Button
+                          variant="outlined"
+                          disabled={isLoading}
+                          component={RouterLink}
+                          to="/"
+                        >
+                          Wróć do logowania
+                        </Button>
+                      </Flex>
+                    </Flex>
+                  </Form>
+                )}
+              </Formik>
+            </Box>
+          </ResetPasswordHiddenWrapper>
+        </Paper>
+      </Flex>
+    </Container>
+  );
+};

--- a/frontend/src/views/ResetPassword/ResetPassword.utils.ts
+++ b/frontend/src/views/ResetPassword/ResetPassword.utils.ts
@@ -1,0 +1,51 @@
+import { ResetPasswordRequestDto, ResetPasswordResponseDto } from '@osk/shared';
+import { Try } from '../../types/Try';
+import { logError } from '../../utils/log';
+import { makeRequest } from '../../utils/makeRequest';
+
+interface SendResetRequestError {
+  type: 'TOKEN_NOT_FOUND' | 'GENERIC';
+  message: string;
+}
+
+export const sendChangePasswordRequest = async (
+  password: string,
+  token: string,
+): Promise<Try<ResetPasswordResponseDto, SendResetRequestError>> => {
+  const requestBody: ResetPasswordRequestDto = {
+    token,
+    password,
+  };
+
+  const response = await makeRequest<
+    ResetPasswordResponseDto,
+    ResetPasswordRequestDto
+  >('/api/reset-password/reset', null, 'POST', requestBody);
+
+  if (response.ok) {
+    return {
+      ok: true,
+      data: response.data,
+    };
+  }
+
+  if (response.error.status === 401) {
+    return {
+      ok: false,
+      error: {
+        type: 'TOKEN_NOT_FOUND',
+        message: 'Nie znaleziono tokenu',
+      },
+    };
+  }
+
+  logError(response.error);
+
+  return {
+    ok: false,
+    error: {
+      type: 'GENERIC',
+      message: 'Wystąpił błąd, spróbuj ponownie później',
+    },
+  };
+};

--- a/frontend/src/views/Trainees/TraineeNew/TraineeNew.tsx
+++ b/frontend/src/views/Trainees/TraineeNew/TraineeNew.tsx
@@ -37,7 +37,6 @@ export const TraineeNew = () => {
           firstName: newTrainee.firstName,
           lastName: newTrainee.lastName,
           phoneNumber: newTrainee.phoneNumber,
-          password: 'password',
           isActive: false,
         },
       },

--- a/shared/src/dto/auth/auth.dto.ts
+++ b/shared/src/dto/auth/auth.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsString, Length } from 'class-validator';
 
 export class LoginAuthRequestDto {
   @ApiProperty({ default: 'admin@example.com' })
@@ -29,7 +29,7 @@ export class ForgotPasswordRequestDto {
 export class ForgotPasswordResponseDto {}
 
 export class ResetPasswordRequestDto {
-  @ApiProperty({ default: '83c39cf95ef7e5179344c2d4721d5c96' })
+  @ApiProperty({ default: '' })
   @IsString()
   @IsNotEmpty()
   token: string;
@@ -37,6 +37,7 @@ export class ResetPasswordRequestDto {
   @ApiProperty({ default: 'password123' })
   @IsString()
   @IsNotEmpty()
+  @Length(8, 64)
   password: string;
 }
 

--- a/shared/src/dto/auth/auth.dto.ts
+++ b/shared/src/dto/auth/auth.dto.ts
@@ -18,3 +18,26 @@ export class LoginAuthResponseDto {
   @IsString()
   accessToken: string;
 }
+
+export class ForgotPasswordRequestDto {
+  @ApiProperty({ default: 'admin@example.com' })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+}
+
+export class ForgotPasswordResponseDto {}
+
+export class ResetPasswordRequestDto {
+  @ApiProperty({ default: '83c39cf95ef7e5179344c2d4721d5c96' })
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+
+  @ApiProperty({ default: 'password123' })
+  @IsString()
+  @IsNotEmpty()
+  password: string;
+}
+
+export class ResetPasswordResponseDto {}

--- a/shared/src/dto/user/user.dto.ts
+++ b/shared/src/dto/user/user.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, PartialType, OmitType } from '@nestjs/swagger';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsBoolean, IsEmail, IsNotEmpty, IsString } from 'class-validator';
 import { DtoOrganization } from '../organization/organization.dto';
@@ -13,10 +13,6 @@ export class DtoUser {
   @IsNotEmpty()
   @IsEmail()
   email: string;
-
-  @ApiProperty()
-  @IsNotEmpty()
-  password: string;
 
   @ApiProperty()
   @IsNotEmpty()
@@ -56,11 +52,6 @@ export class DtoCreateUser {
   @ApiProperty()
   @IsNotEmpty()
   @IsString()
-  password: string;
-
-  @ApiProperty()
-  @IsNotEmpty()
-  @IsString()
   firstName: string;
 
   @ApiProperty()
@@ -79,9 +70,7 @@ export class DtoCreateUser {
   phoneNumber: string;
 }
 
-export class DtoUpdateUser extends OmitType(PartialType(DtoCreateUser), [
-  'password',
-]) {}
+export class DtoUpdateUser extends PartialType(DtoCreateUser) {}
 
 export class UserAddNewResponseDto {
   @ApiProperty()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2904,6 +2904,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nextnm/nestjs-mailgun@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@nextnm/nestjs-mailgun@npm:2.0.0"
+  dependencies:
+    form-data: ^4.0.0
+    mailgun.js: ^3.7.3
+    reflect-metadata: ^0.1.13
+    rxjs: ^6.6.7
+  peerDependencies:
+    "@nestjs/common": ^7.0.7
+  checksum: 78aa2d66a93d465d9471d791a600140cb9d3617e0454ead05d3ee2b4396e6efd7b3bdd28eb401856551f732e923eac4fb7f433ff709a602a9dc6ff312c4738b6
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -2986,6 +3000,7 @@ __metadata:
     "@nestjs/swagger": ^5.2.1
     "@nestjs/testing": ^8.0.0
     "@nestjs/typeorm": ^8.0.3
+    "@nextnm/nestjs-mailgun": ^2.0.0
     "@osk/eslint-plugin": 1.0.0
     "@osk/shared": 1.0.0
     "@types/bcrypt": ^5.0.0
@@ -4567,6 +4582,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abort-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "abort-controller@npm:3.0.0"
+  dependencies:
+    event-target-shim: ^5.0.0
+  checksum: 170bdba9b47b7e65906a28c8ce4f38a7a369d78e2271706f020849c1bfe0ee2067d4261df8bbb66eb84f79208fd5b710df759d64191db58cfba7ce8ef9c54b75
+  languageName: node
+  linkType: hard
+
 "accepts@npm:~1.3.8":
   version: 1.3.8
   resolution: "accepts@npm:1.3.8"
@@ -5106,6 +5130,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base-64@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "base-64@npm:1.0.0"
+  checksum: d10b64a1fc9b2c5a5f39f1ce1e6c9d1c5b249222bbfa3a0604c592d90623caf74419983feadd8a170f27dc0c3389704f72faafa3e645aeb56bfc030c93ff074a
+  languageName: node
+  linkType: hard
+
 "base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
@@ -5138,6 +5169,13 @@ __metadata:
     inherits: ^2.0.4
     readable-stream: ^3.4.0
   checksum: 9e8521fa7e83aa9427c6f8ccdcba6e8167ef30cc9a22df26effcc5ab682ef91d2cbc23a239f945d099289e4bbcfae7a192e9c28c84c6202e710a0dfec3722662
+  languageName: node
+  linkType: hard
+
+"bluebird@npm:^3.7.2":
+  version: 3.7.2
+  resolution: "bluebird@npm:3.7.2"
+  checksum: 869417503c722e7dc54ca46715f70e15f4d9c602a423a02c825570862d12935be59ed9c7ba34a9b31f186c017c23cac6b54e35446f8353059c101da73eac22ef
   languageName: node
   linkType: hard
 
@@ -5944,6 +5982,13 @@ __metadata:
   version: 1.0.8
   resolution: "damerau-levenshtein@npm:1.0.8"
   checksum: d240b7757544460ae0586a341a53110ab0a61126570ef2d8c731e3eab3f0cb6e488e2609e6a69b46727635de49be20b071688698744417ff1b6c1d7ccd03e0de
+  languageName: node
+  linkType: hard
+
+"data-uri-to-buffer@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "data-uri-to-buffer@npm:3.0.1"
+  checksum: c59c3009686a78c071806b72f4810856ec28222f0f4e252aa495ec027ed9732298ceea99c50328cf59b151dd34cbc3ad6150bbb43e41fc56fa19f48c99e9fc30
   languageName: node
   linkType: hard
 
@@ -6941,6 +6986,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"event-target-shim@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "event-target-shim@npm:5.0.1"
+  checksum: 1ffe3bb22a6d51bdeb6bf6f7cf97d2ff4a74b017ad12284cc9e6a279e727dc30a5de6bb613e5596ff4dc3e517841339ad09a7eec44266eccb1aa201a30448166
+  languageName: node
+  linkType: hard
+
 "events@npm:^3.2.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
@@ -7094,6 +7146,16 @@ __metadata:
   dependencies:
     reusify: ^1.0.4
   checksum: 32cf15c29afe622af187d12fc9cd93e160a0cb7c31a3bb6ace86b7dea3b28e7b72acde89c882663f307b2184e14782c6c664fa315973c03626c7d4bff070bb0b
+  languageName: node
+  linkType: hard
+
+"fetch-blob@npm:^2.1.1":
+  version: 2.1.2
+  resolution: "fetch-blob@npm:2.1.2"
+  peerDependenciesMeta:
+    domexception:
+      optional: true
+  checksum: 22d4487ce78ea4e52b432b0057d8d42922d5d93c0374b0bc2692cebdcb11bf8fac4f6d141b31f1633db1e9212effd38385adbd765a2c7412a621307058499214
   languageName: node
   linkType: hard
 
@@ -8537,6 +8599,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ky-universal@npm:^0.8.2":
+  version: 0.8.2
+  resolution: "ky-universal@npm:0.8.2"
+  dependencies:
+    abort-controller: ^3.0.0
+    node-fetch: 3.0.0-beta.9
+  peerDependencies:
+    ky: ">=0.17.0"
+    web-streams-polyfill: ">=2.0.0"
+  peerDependenciesMeta:
+    web-streams-polyfill:
+      optional: true
+  checksum: 87ed38c5c5a5b4448502fd5a64b68f30db69d366e148e5321cd9c0cb57d616519578ff0ae50146ff92ad037ef5cd77fbc40d893675459eead0d3f13101374570
+  languageName: node
+  linkType: hard
+
+"ky@npm:^0.25.1":
+  version: 0.25.1
+  resolution: "ky@npm:0.25.1"
+  checksum: ae1b7bebb48001d00d53e386e077939eeef7398a36b4fb45660f988ddb17d583d077290f2adb9706b4761f9d3b74918eb8d9f45ce799760143e104e1053b33ef
+  languageName: node
+  linkType: hard
+
 "language-subtag-registry@npm:~0.3.2":
   version: 0.3.21
   resolution: "language-subtag-registry@npm:0.3.21"
@@ -8798,6 +8883,22 @@ __metadata:
   dependencies:
     sourcemap-codec: ^1.4.8
   checksum: 9a0e55a15c7303fc360f9572a71cffba1f61451bc92c5602b1206c9d17f492403bf96f946dfce7483e66822d6b74607262e24392e87b0ac27b786e69a40e9b1a
+  languageName: node
+  linkType: hard
+
+"mailgun.js@npm:^3.7.3":
+  version: 3.7.3
+  resolution: "mailgun.js@npm:3.7.3"
+  dependencies:
+    base-64: ^1.0.0
+    bluebird: ^3.7.2
+    ky: ^0.25.1
+    ky-universal: ^0.8.2
+    url: ^0.11.0
+    url-join: 0.0.1
+    web-streams-polyfill: ^3.0.1
+    webpack-merge: ^5.4.0
+  checksum: ba1ca396a65e9d704632c5d94fbd86df3c19dd92c98d7addd107b7f130cf0f8b18de9918d73047cf12aa427b17d83c9180f4a099936771c9bf85dc5b10e0f695
   languageName: node
   linkType: hard
 
@@ -9208,6 +9309,16 @@ __metadata:
   dependencies:
     lodash: ^4.17.21
   checksum: e8c856c04a1645062112a72e59a98b203505ed5111ff84a3a5f40611afa229b578c7d50f1e6a7f17aa62baeea4a640d2e2f61f63afc05423aa267af10977fb2b
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:3.0.0-beta.9":
+  version: 3.0.0-beta.9
+  resolution: "node-fetch@npm:3.0.0-beta.9"
+  dependencies:
+    data-uri-to-buffer: ^3.0.1
+    fetch-blob: ^2.1.1
+  checksum: 586af0910649cb62f1c044ddac41e71c0b0f48133fba406ad5e0fab51baff18f22cd187ea65ef690ceed7386a71910e904348105dc8eae55f907fa94df7e76ca
   languageName: node
   linkType: hard
 
@@ -10199,6 +10310,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"punycode@npm:1.3.2":
+  version: 1.3.2
+  resolution: "punycode@npm:1.3.2"
+  checksum: b8807fd594b1db33335692d1f03e8beeddde6fda7fbb4a2e32925d88d20a3aa4cd8dcc0c109ccaccbd2ba761c208dfaaada83007087ea8bfb0129c9ef1b99ed6
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^2.1.0, punycode@npm:^2.1.1":
   version: 2.1.1
   resolution: "punycode@npm:2.1.1"
@@ -10221,6 +10339,13 @@ __metadata:
   dependencies:
     side-channel: ^1.0.4
   checksum: 0fac5e6c7191d0295a96d0e83c851aeb015df7e990e4d3b093897d3ac6c94e555dbd0a599739c84d7fa46d7fee282d94ba76943983935cf33bba6769539b8019
+  languageName: node
+  linkType: hard
+
+"querystring@npm:0.2.0":
+  version: 0.2.0
+  resolution: "querystring@npm:0.2.0"
+  checksum: 8258d6734f19be27e93f601758858c299bdebe71147909e367101ba459b95446fbe5b975bf9beb76390156a592b6f4ac3a68b6087cea165c259705b8b4e56a69
   languageName: node
   linkType: hard
 
@@ -11073,7 +11198,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:6.6.7, rxjs@npm:^6.6.0":
+"rxjs@npm:6.6.7, rxjs@npm:^6.6.0, rxjs@npm:^6.6.7":
   version: 6.6.7
   resolution: "rxjs@npm:6.6.7"
   dependencies:
@@ -12398,12 +12523,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"url-join@npm:0.0.1":
+  version: 0.0.1
+  resolution: "url-join@npm:0.0.1"
+  checksum: f1d75a8fea205337a4310c90f9fa72e4d9204e16c4d2494b553d899420aa0a2bd91af9e5cddade005e536b8058b4eee43d2405c76bc852eb9ebf8f4e0ba3c7ec
+  languageName: node
+  linkType: hard
+
 "url-parse-lax@npm:^3.0.0":
   version: 3.0.0
   resolution: "url-parse-lax@npm:3.0.0"
   dependencies:
     prepend-http: ^2.0.0
   checksum: 1040e357750451173132228036aff1fd04abbd43eac1fb3e4fca7495a078bcb8d33cb765fe71ad7e473d9c94d98fd67adca63bd2716c815a2da066198dd37217
+  languageName: node
+  linkType: hard
+
+"url@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "url@npm:0.11.0"
+  dependencies:
+    punycode: 1.3.2
+    querystring: 0.2.0
+  checksum: 50d100d3dd2d98b9fe3ada48cadb0b08aa6be6d3ac64112b867b56b19be4bfcba03c2a9a0d7922bfd7ac17d4834e88537749fe182430dfd9b68e520175900d90
   languageName: node
   linkType: hard
 
@@ -12545,10 +12687,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"web-streams-polyfill@npm:^3.0.1":
+  version: 3.2.1
+  resolution: "web-streams-polyfill@npm:3.2.1"
+  checksum: b119c78574b6d65935e35098c2afdcd752b84268e18746606af149e3c424e15621b6f1ff0b42b2676dc012fc4f0d313f964b41a4b5031e525faa03997457da02
+  languageName: node
+  linkType: hard
+
 "webidl-conversions@npm:^3.0.0":
   version: 3.0.1
   resolution: "webidl-conversions@npm:3.0.1"
   checksum: c92a0a6ab95314bde9c32e1d0a6dfac83b578f8fa5f21e675bc2706ed6981bc26b7eb7e6a1fab158e5ce4adf9caa4a0aee49a52505d4d13c7be545f15021b17c
+  languageName: node
+  linkType: hard
+
+"webpack-merge@npm:^5.4.0":
+  version: 5.8.0
+  resolution: "webpack-merge@npm:5.8.0"
+  dependencies:
+    clone-deep: ^4.0.1
+    wildcard: ^2.0.0
+  checksum: 88786ab91013f1bd2a683834ff381be81c245a4b0f63304a5103e90f6653f44dab496a0768287f8531761f8ad957d1f9f3ccb2cb55df0de1bd9ee343e079da26
   languageName: node
   linkType: hard
 
@@ -12689,6 +12848,13 @@ __metadata:
   dependencies:
     string-width: ^4.0.0
   checksum: 03db6c9d0af9329c37d74378ff1d91972b12553c7d72a6f4e8525fe61563fa7adb0b9d6e8d546b7e059688712ea874edd5ded475999abdeedf708de9849310e0
+  languageName: node
+  linkType: hard
+
+"wildcard@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "wildcard@npm:2.0.0"
+  checksum: 1f4fe4c03dfc492777c60f795bbba597ac78794f1b650d68f398fbee9adb765367c516ebd4220889b6a81e9626e7228bbe0d66237abb311573c2ee1f4902a5ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces:
* Mailgun integration (a new service)
* UI for resetting password
![CleanShot 2022-10-02 at 22 15 03@2x](https://user-images.githubusercontent.com/14880213/193474358-1023e95c-60a5-498b-b8c7-f1d589b58f4d.png)
![CleanShot 2022-10-02 at 22 14 43@2x](https://user-images.githubusercontent.com/14880213/193474363-067cf4bf-91bd-419b-9e7d-284d1b174e19.png)

* Backend support for resetting password
  * `/api/reset-password/forgot` — sends an email to the user (if exists) with a link containing reset token
  * `/api/reset-password/reset` — the request requires a valid token (valid for 1 hour) and a new password that matches password requirements (8-64 characters)
    <img width="757" alt="CleanShot 2022-10-02 at 22 19 05@2x" src="https://user-images.githubusercontent.com/14880213/193474514-8ad45bb8-1ecd-4777-bf7c-08acc13aa33c.png">
    <a href="https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls">OWASP Authentication Cheat Sheet</a>

* Reset password email is also being sent upon creation of a trainee

## What part of the app is affected?
* [x] Frontend
* [x] Backend
