### PR TITLE
Use relationId instead of mapping categories to list of ids

### DIFF
--- a/backend/src/instructors/instructors.controller.ts
+++ b/backend/src/instructors/instructors.controller.ts
@@ -39,17 +39,9 @@ export class InstructorsController {
     @Request() request: AuthRequest,
   ): Promise<InstructorFindAllResponseDto> {
     const { role } = request.user;
-    const instructorsData = await this.instructorsService.findAll(
+    const instructors = await this.instructorsService.findAll(
       role === UserRole.Trainee ? true : undefined,
     );
-    const instructors = instructorsData.map((instructor) => {
-      return {
-        ...instructor,
-        instructorsQualifications: instructor.instructorsQualifications.map(
-          (category) => category.id,
-        ),
-      };
-    });
 
     return { instructors };
   }
@@ -61,22 +53,13 @@ export class InstructorsController {
   async findOne(
     @Param('id', ParseIntPipe) id: number,
   ): Promise<InstructorFindOneResponseDto> {
-    const instructorData = await this.instructorsService.findOne(+id);
+    const instructor = await this.instructorsService.findOne(+id);
 
-    if (instructorData === null) {
+    if (instructor === null) {
       throw new NotFoundException();
     }
 
-    const instructor = {
-      ...instructorData,
-      instructorsQualifications: instructorData.instructorsQualifications.map(
-        (category) => category.id,
-      ),
-    };
-
-    return {
-      instructor,
-    };
+    return { instructor };
   }
 
   @ApiResponse({

--- a/backend/src/instructors/instructors.service.ts
+++ b/backend/src/instructors/instructors.service.ts
@@ -79,7 +79,7 @@ export class InstructorsService {
 
     const instructorsQualifications =
       await this.driversLicenseCategoryService.findCategoriesById(
-        instructor.instructorsQualifications,
+        instructor.instructorsQualificationsIds,
       );
 
     if (instructorsQualifications === undefined) {
@@ -146,7 +146,7 @@ export class InstructorsService {
       );
     }
     const {
-      instructorsQualifications: updatedQualifications,
+      instructorsQualificationsIds: updatedQualifications,
       ...restOfArguments
     } = instructor;
 

--- a/backend/src/instructors/instructors.types.ts
+++ b/backend/src/instructors/instructors.types.ts
@@ -4,7 +4,7 @@ export interface InstructorFields {
   user: UserArguments;
   registrationNumber: string;
   licenseNumber: string;
-  instructorsQualifications: number[];
+  instructorsQualificationsIds: number[];
   photo: string | null;
 }
 

--- a/backend/src/lessons/lessons.controller.ts
+++ b/backend/src/lessons/lessons.controller.ts
@@ -59,10 +59,6 @@ export class LessonsController {
     lessonsData.forEach((lessonData) => {
       const instructor = {
         ...lessonData.instructor,
-        instructorsQualifications:
-          lessonData.instructor.instructorsQualifications.map(
-            (category) => category.id,
-          ),
       };
 
       const lesson = { ...lessonData, instructor };

--- a/frontend/src/views/Instructors/InstructorsDetails/InstructorsDetails.tsx
+++ b/frontend/src/views/Instructors/InstructorsDetails/InstructorsDetails.tsx
@@ -68,7 +68,7 @@ export const InstructorsDetails = () => {
     email: instructor.user.email,
     licenseNumber: instructor.licenseNumber,
     registrationNumber: instructor.registrationNumber,
-    instructorsQualifications: instructor.instructorsQualifications,
+    instructorsQualificationsIds: instructor.instructorsQualificationsIds,
     phoneNumber: instructor.user.phoneNumber,
   };
 
@@ -86,14 +86,14 @@ export const InstructorsDetails = () => {
       photo,
       registrationNumber,
       licenseNumber,
-      instructorsQualifications,
+      instructorsQualificationsIds,
       ...userValues
     } = initialValues;
     const body: InstructorUpdateRequestDto = {
       instructor: {
         registrationNumber,
         licenseNumber,
-        instructorsQualifications,
+        instructorsQualificationsIds,
         user: {
           ...userValues,
           isActive: !instructor.user.isActive,

--- a/frontend/src/views/Instructors/InstructorsEdit/InstructorsEdit.tsx
+++ b/frontend/src/views/Instructors/InstructorsEdit/InstructorsEdit.tsx
@@ -54,7 +54,7 @@ export const InstructorsEdit = () => {
     email: instructor.user.email,
     licenseNumber: instructor.licenseNumber,
     registrationNumber: instructor.registrationNumber,
-    instructorsQualifications: instructor.instructorsQualifications,
+    instructorsQualificationsIds: instructor.instructorsQualificationsIds,
     phoneNumber: instructor.user.phoneNumber,
   };
 
@@ -63,14 +63,14 @@ export const InstructorsEdit = () => {
       photo,
       registrationNumber,
       licenseNumber,
-      instructorsQualifications,
+      instructorsQualificationsIds,
       ...userValues
     } = instructorValues;
     const body: InstructorUpdateRequestDto = {
       instructor: {
         registrationNumber,
         licenseNumber,
-        instructorsQualifications,
+        instructorsQualificationsIds,
         user: { ...userValues },
         photo,
       },

--- a/frontend/src/views/Instructors/InstructorsForm/InstructorsForm.schema.ts
+++ b/frontend/src/views/Instructors/InstructorsForm/InstructorsForm.schema.ts
@@ -9,7 +9,7 @@ export interface InstructorsFormData {
   licenseNumber: string;
   registrationNumber: string;
   photo?: string | null;
-  instructorsQualifications: number[];
+  instructorsQualificationsIds: number[];
 }
 
 setupYupLocale();
@@ -29,5 +29,5 @@ export const instructorsFormSchema: Yup.SchemaOf<InstructorsFormData> =
       .matches(/[\d\w]{6}/)
       .required(),
     registrationNumber: Yup.string().length(6).matches(/\d{6}/).required(),
-    instructorsQualifications: Yup.array().of(Yup.number().required()),
+    instructorsQualificationsIds: Yup.array().of(Yup.number().required()),
   });

--- a/frontend/src/views/Instructors/InstructorsForm/InstructorsForm.tsx
+++ b/frontend/src/views/Instructors/InstructorsForm/InstructorsForm.tsx
@@ -33,7 +33,7 @@ const defaultValues: InstructorsFormData = {
   phoneNumber: '',
   licenseNumber: '',
   registrationNumber: '',
-  instructorsQualifications: [],
+  instructorsQualificationsIds: [],
   photo: '',
 };
 
@@ -54,7 +54,6 @@ export const InstructorsForm = ({
           return { value: el.id, label: el.name };
         })
       : [];
-
   return (
     <Formik<InstructorsFormData>
       initialValues={initialValues ?? defaultValues}
@@ -112,12 +111,14 @@ export const InstructorsForm = ({
               disabled={disabled}
             />
             <FPicklistField
-              id="instructorsQualifications"
+              id="instructorsQualificationsIds"
               label="Uprawnienia"
-              name="instructorsQualifications"
+              name="instructorsQualificationsIds"
               disabled={disabled}
               options={driversLicenseCategoryOptions}
-              predefinedValues={initialValues?.instructorsQualifications ?? []}
+              predefinedValues={
+                initialValues?.instructorsQualificationsIds ?? []
+              }
               multiple
             />
             {actions && <div>{actions}</div>}

--- a/frontend/src/views/Instructors/InstructorsList/InstructorsList.tsx
+++ b/frontend/src/views/Instructors/InstructorsList/InstructorsList.tsx
@@ -100,7 +100,7 @@ export const InstructorsList = () => {
                 <TableCell>{row.user.email}</TableCell>
                 <TableCell>{row.user.phoneNumber}</TableCell>
                 <TableCell>
-                  {row.instructorsQualifications
+                  {row.instructorsQualificationsIds
                     .map((id) => qualifications[id.toString()])
                     .join(', ')}
                 </TableCell>

--- a/frontend/src/views/Instructors/InstructorsNew/InstructorsNew.tsx
+++ b/frontend/src/views/Instructors/InstructorsNew/InstructorsNew.tsx
@@ -31,14 +31,14 @@ export const InstructorsNew = () => {
       photo,
       registrationNumber,
       licenseNumber,
-      instructorsQualifications,
+      instructorsQualificationsIds,
       ...userValues
     } = instructorValues;
     const body: InstructorCreateRequestDto = {
       instructor: {
         registrationNumber,
         licenseNumber,
-        instructorsQualifications,
+        instructorsQualificationsIds,
         user: { ...userValues, isActive: false },
         photo: photo ?? null,
       },

--- a/shared/src/dto/instructor/instructor.dto.ts
+++ b/shared/src/dto/instructor/instructor.dto.ts
@@ -39,7 +39,7 @@ export class DtoInstructor {
   @ApiProperty()
   @IsNotEmpty()
   @IsNumber({}, { each: true })
-  instructorsQualifications: number[];
+  instructorsQualificationsIds: number[];
 
   @ApiPropertyOptional({ nullable: true, type: 'string' })
   @IsOptional()
@@ -67,7 +67,7 @@ export class DtoCreateInstructor {
   @ApiProperty()
   @IsNotEmpty()
   @IsNumber({}, { each: true })
-  instructorsQualifications: number[];
+  instructorsQualificationsIds: number[];
 
   @ApiPropertyOptional({ nullable: true, type: 'string' })
   @IsOptional()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
In order to avoid mapping DriversLicenseCategories into actually usefull array of Ids, we added instructorsQualificationsIds so that we have now the required array otb

## What part of the app is affected?
* [x] Frontend
* [x] Backend
* [ ] Infrastructure

## Screenshots or Video Recording (if appropriate):
<!-- Provide some Screenshots or Video Recordings -->
