### PR TITLE
Fix org not found error message, add error boundary to FE

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -53,6 +53,7 @@ import { MockExamQuestionModule } from './mockExamQuestion/mockExamQuestion.modu
     }),
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '../..', 'client'),
+      exclude: ['/api*'],
     }),
     AuthModule,
     AnnouncementsModule,

--- a/backend/src/organization-domain/organization-domain.middleware.ts
+++ b/backend/src/organization-domain/organization-domain.middleware.ts
@@ -18,6 +18,11 @@ export class OrganizationDomainMiddleware implements NestMiddleware {
     const subdomains = domain?.split('.');
     const firstSubdomain = subdomains?.[0];
 
+    if (!req.baseUrl.startsWith('/api')) {
+      next();
+      return;
+    }
+
     if (!firstSubdomain) {
       throw new NotFoundException();
     }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,93 +24,96 @@ import { AnnouncementsList } from './views/Announcements/AnnouncementsList';
 import { Availability } from './views/Availability/Availability';
 import { DefaultAvailability } from './views/DefaultAvailability/DefaultAvailability';
 import { SignUp } from './views/SignUp/SignUp';
+import { ErrorBoundary } from './components/ErrorBoundary/ErrorBoundary';
 
 export const App = () => {
   return (
-    <Routes>
-      <Route path="/login" element={<Login />} />
-      <Route path="/zapisz-sie" element={<SignUp />} />
-      <Route path="/account/zapomnialem-haslo" element={<ForgotPassword />} />
-      <Route path="/account/reset">
-        <Route index element={<Navigate to="/account/zapomnialem-haslo" />} />
-        <Route path=":token" element={<ResetPassword />} />
-      </Route>
-      <Route
-        path="/"
-        element={
-          <Layout>
-            <RequireAuth />
-          </Layout>
-        }
-      >
-        <Route index element={<HomePage />} />
+    <ErrorBoundary>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/zapisz-sie" element={<SignUp />} />
+        <Route path="/account/zapomnialem-haslo" element={<ForgotPassword />} />
+        <Route path="/account/reset">
+          <Route index element={<Navigate to="/account/zapomnialem-haslo" />} />
+          <Route path=":token" element={<ResetPassword />} />
+        </Route>
         <Route
-          path="/kursanci"
+          path="/"
           element={
-            <RequireRole roles={[UserRole.Admin, UserRole.Instructor]} />
+            <Layout>
+              <RequireAuth />
+            </Layout>
           }
         >
-          <Route index element={<TraineesList />} />
-          <Route path="nowy" element={<TraineeNew />} />
-          <Route path=":traineeId" element={<TraineeDetails />} />
-          <Route path=":traineeId/edytuj" element={<TraineeEdit />} />
+          <Route index element={<HomePage />} />
+          <Route
+            path="/kursanci"
+            element={
+              <RequireRole roles={[UserRole.Admin, UserRole.Instructor]} />
+            }
+          >
+            <Route index element={<TraineesList />} />
+            <Route path="nowy" element={<TraineeNew />} />
+            <Route path=":traineeId" element={<TraineeDetails />} />
+            <Route path=":traineeId/edytuj" element={<TraineeEdit />} />
+          </Route>
+          <Route
+            path="/instruktorzy"
+            element={
+              <RequireRole roles={[UserRole.Admin, UserRole.Instructor]} />
+            }
+          >
+            <Route index element={<InstructorsList />} />
+            <Route path="nowy" element={<InstructorsNew />} />
+            <Route path=":instructorId/edytuj" element={<InstructorsEdit />} />
+            <Route path=":instructorId" element={<InstructorsDetails />} />
+          </Route>
+          <Route
+            path="/pojazdy"
+            element={
+              <RequireRole roles={[UserRole.Admin, UserRole.Instructor]} />
+            }
+          >
+            <Route index element={<VehiclesList />} />
+            <Route path="nowy" element={<VehicleNew />} />
+            <Route path=":vehicleId/edytuj" element={<VehicleEdit />} />
+            <Route path=":vehicleId" element={<VehicleDetails />} />
+          </Route>
+          <Route
+            path="/ogloszenia"
+            element={
+              <RequireRole
+                roles={[UserRole.Admin, UserRole.Instructor, UserRole.Trainee]}
+              />
+            }
+          >
+            <Route index element={<AnnouncementsList />} />
+          </Route>
+          <Route
+            path="/moje-jazdy"
+            element={
+              <RequireRole roles={[UserRole.Trainee, UserRole.Instructor]} />
+            }
+          >
+            <Route index element={<MyLessons />} />
+          </Route>
+          <Route
+            path="/moja-dostepnosc"
+            element={<RequireRole role={UserRole.Instructor} />}
+          >
+            <Route index element={<Availability />} />
+            <Route path="domyslna" element={<DefaultAvailability />} />
+          </Route>
+          <Route
+            path="/ogloszenia"
+            element={
+              <RequireRole roles={[UserRole.Trainee, UserRole.Instructor]} />
+            }
+          >
+            <Route index element={null} />
+          </Route>
         </Route>
-        <Route
-          path="/instruktorzy"
-          element={
-            <RequireRole roles={[UserRole.Admin, UserRole.Instructor]} />
-          }
-        >
-          <Route index element={<InstructorsList />} />
-          <Route path="nowy" element={<InstructorsNew />} />
-          <Route path=":instructorId/edytuj" element={<InstructorsEdit />} />
-          <Route path=":instructorId" element={<InstructorsDetails />} />
-        </Route>
-        <Route
-          path="/pojazdy"
-          element={
-            <RequireRole roles={[UserRole.Admin, UserRole.Instructor]} />
-          }
-        >
-          <Route index element={<VehiclesList />} />
-          <Route path="nowy" element={<VehicleNew />} />
-          <Route path=":vehicleId/edytuj" element={<VehicleEdit />} />
-          <Route path=":vehicleId" element={<VehicleDetails />} />
-        </Route>
-        <Route
-          path="/ogloszenia"
-          element={
-            <RequireRole
-              roles={[UserRole.Admin, UserRole.Instructor, UserRole.Trainee]}
-            />
-          }
-        >
-          <Route index element={<AnnouncementsList />} />
-        </Route>
-        <Route
-          path="/moje-jazdy"
-          element={
-            <RequireRole roles={[UserRole.Trainee, UserRole.Instructor]} />
-          }
-        >
-          <Route index element={<MyLessons />} />
-        </Route>
-        <Route
-          path="/moja-dostepnosc"
-          element={<RequireRole role={UserRole.Instructor} />}
-        >
-          <Route index element={<Availability />} />
-          <Route path="domyslna" element={<DefaultAvailability />} />
-        </Route>
-        <Route
-          path="/ogloszenia"
-          element={
-            <RequireRole roles={[UserRole.Trainee, UserRole.Instructor]} />
-          }
-        >
-          <Route index element={null} />
-        </Route>
-      </Route>
-    </Routes>
+      </Routes>
+    </ErrorBoundary>
   );
 };

--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable react/destructuring-assignment */
+import { Container, Paper } from '@mui/material';
+import { Component } from 'react';
+import { Flex } from 'reflexbox';
+import { GeneralAPIError } from '../GeneralAPIError/GeneralAPIError';
+
+interface ErrorBoundaryProps {
+  children: JSX.Element;
+}
+interface ErrorBoundaryState {
+  didThrow: boolean;
+}
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  // eslint-disable-next-line react/state-in-constructor
+  public state: ErrorBoundaryState = {
+    didThrow: false,
+  };
+
+  static getDerivedStateFromError() {
+    return { didThrow: true };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: unknown) {
+    // eslint-disable-next-line no-console
+    console.error(error, errorInfo);
+  }
+
+  public render() {
+    if (this.state.didThrow) {
+      return (
+        <Container component="main" maxWidth="sm">
+          <Flex width="100%" height="100vh" alignItems="center">
+            <Paper sx={{ width: '100%', position: 'relative' }} elevation={2}>
+              <GeneralAPIError />
+            </Paper>
+          </Flex>
+        </Container>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Description
* Setup org check middleware to skip static files
  * Currently if you enter a domain that is assigned to a nonexistent org, it'll show a `{"statusCode":404,"message":"Not Found"}` JSON (note: this can only be visible a production build, where node.js process is serving the frontend)
  ![CleanShot 2023-02-12 at 20 16 09@2x](https://user-images.githubusercontent.com/14880213/218332092-833071e1-5d7f-46f3-b0b3-33e3f52257df.png)

* Add error boundary to FE
  * What is error boundary? It's a special wrapper around the whole app that, if any error occurs down the children's tree, it'll display a nice error message instead of just showing an empty screen

## What part of the app is affected?
* [x] Frontend
* [x] Backend
* [ ] Infrastructure
