### PR TITLE
Fixed bug on edit vehicle caused by null value in photo

### DIFF
--- a/frontend/src/views/Vehicles/VehicleDetails/VehicleDetails.tsx
+++ b/frontend/src/views/Vehicles/VehicleDetails/VehicleDetails.tsx
@@ -90,7 +90,7 @@ export const VehicleDetails = () => {
     dateOfNextCheck: parseISO(vehicle.dateOfNextCheck),
     additionalDetails: vehicle.additionalDetails ?? undefined,
     notes: vehicle.notes ?? undefined,
-    photo: vehicle.photo,
+    photo: vehicle.photo ?? undefined,
   };
 
   return (

--- a/frontend/src/views/Vehicles/VehiclesEdit/VehiclesEdit.tsx
+++ b/frontend/src/views/Vehicles/VehiclesEdit/VehiclesEdit.tsx
@@ -87,7 +87,7 @@ export const VehicleEdit = () => {
     dateOfNextCheck: parseISO(vehicle.dateOfNextCheck),
     additionalDetails: vehicle.additionalDetails ?? undefined,
     notes: vehicle.notes ?? undefined,
-    photo: vehicle.photo,
+    photo: vehicle.photo ?? undefined,
   };
 
   return (

--- a/frontend/src/views/Vehicles/VehiclesForm/VehiclesForm.schema.tsx
+++ b/frontend/src/views/Vehicles/VehiclesForm/VehiclesForm.schema.tsx
@@ -8,7 +8,7 @@ export interface VehiclesFormData {
   dateOfNextCheck: Date | null;
   additionalDetails?: string;
   notes?: string;
-  photo?: string | null;
+  photo?: string;
 }
 
 export interface VehiclesSubmitData extends VehiclesFormData {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Vehicles were not possible to be modified if the value of the photo was set to null

## What part of the app is affected?
* [x] Frontend
* [ ] Backend
* [ ] Infrastructure
